### PR TITLE
Align Android status bar with active theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .aider*
+node_modules/
+dist/

--- a/android/app/src/main/java/com/my/vivica/MainActivity.java
+++ b/android/app/src/main/java/com/my/vivica/MainActivity.java
@@ -3,7 +3,6 @@ package com.my.vivica;
 import android.os.Bundle;
 import android.view.Window;
 import android.view.WindowManager;
-import android.view.View;
 import androidx.core.content.ContextCompat;
 import com.getcapacitor.BridgeActivity;
 
@@ -13,34 +12,10 @@ public class MainActivity extends BridgeActivity {
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
+    // Set an initial status bar color. The web app updates this dynamically
+    // to match the active theme via the Capacitor StatusBar plugin.
     Window window = getWindow();
-
-    // Set status bar color from our theme
     int statusBarColor = ContextCompat.getColor(this, R.color.status_bar_color);
     window.setStatusBarColor(statusBarColor);
-
-    // Check if the status bar color is light and adjust text color accordingly
-    if (isColorLight(statusBarColor)) {
-      // For light status bar, make icons dark
-      window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
-    } else {
-      // For dark status bar, clear any light status bar flag
-      window.getDecorView().setSystemUiVisibility(0);
-    }
-  }
-
-  /**
-   * Determines if a color is light or dark based on luminance
-   */
-  private boolean isColorLight(int color) {
-    int red = (color >> 16) & 0xFF;
-    int green = (color >> 8) & 0xFF;
-    int blue = color & 0xFF;
-    
-    // Calculate luminance using standard formula
-    double luminance = (0.299 * red + 0.587 * green + 0.114 * blue) / 255;
-    
-    // If luminance is > 0.5, it's a light color
-    return luminance > 0.5;
   }
 }

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -81,7 +81,7 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
       }
     };
     applyStatusBar();
-  }, [color, variant]);
+  }, [color, variant, currentMood]);
 
   useDynamicTheme(currentMood, variant, color === 'ai-choice');
 


### PR DESCRIPTION
## Summary
- Let MainActivity set an initial status bar color and defer further styling to the web app
- Refresh Capacitor status bar styling whenever theme or mood changes
- Ignore build artefacts and node modules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `cd android && ./gradlew test` *(fails: Could not read script 'capacitor-cordova-android-plugins/cordova.variables.gradle')*


------
https://chatgpt.com/codex/tasks/task_e_689f6e572c3c832aa7e156b6773b6665