### PR TITLE
fix(android): correct status bar icon style

### DIFF
--- a/src/lib/statusBar.ts
+++ b/src/lib/statusBar.ts
@@ -47,5 +47,6 @@ export async function applyStatusBarTheme(theme: ThemeKey) {
 
   // icon color chosen from background luminance
   const useLightIcons = isDarkBg(color)
-  await StatusBar.setStyle({ style: useLightIcons ? Style.Light : Style.Dark })
+  // Capacitor uses Style.Dark for light content (white icons)
+  await StatusBar.setStyle({ style: useLightIcons ? Style.Dark : Style.Light })
 }


### PR DESCRIPTION
## Summary
- fix mapping of light/dark status bar icons so Android status bar follows theme

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1ff02b1e4832abaa3526c07bbc7c3