### PR TITLE
Improve Android status bar theming

### DIFF
--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -2,7 +2,7 @@
 <resources>
     <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Dark theme specific overrides -->
-        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">@color/statusbar_color</item>
         <item name="android:windowLightStatusBar">false</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
         <item name="android:fitsSystemWindows">false</item>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-        <!-- Will be transparent by default -->
-        <item name="android:statusBarColor">@android:color/transparent</item>
-        <!-- Use system bars behavior -->
-        <item name="android:windowLightStatusBar">?android:attr/windowLightStatusBar</item>
+        <!-- Default fallback color; JS/Capacitor will update dynamically -->
+        <item name="android:statusBarColor">@color/statusbar_color</item>
+        <!-- Start with light icons to ensure contrast -->
+        <item name="android:windowLightStatusBar">false</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
         <item name="android:fitsSystemWindows">false</item>
     </style>

--- a/index.html
+++ b/index.html
@@ -19,41 +19,41 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:image" content="uploads/790c3ad0-f2a541ef-ac83-99cb6bdd3112.png" />
 
-    <!-- Dynamically update the status bar theme color based on the app's theme -->
+    <!-- Set initial status bar theme color based on saved theme -->
     <script>
       (function () {
+        const STATUSBAR_BG = {
+          'default-dark': '#000000',
+          'default-light': '#FFFFFF',
+          'red-dark': '#7A0E1B',
+          'red-light': '#FFD5D9',
+          'blue-dark': '#0A1C3A',
+          'blue-light': '#DDE9FF',
+          'green-dark': '#0F2D1E',
+          'green-light': '#D8F5E3',
+          'purple-dark': '#0B0512',
+          'purple-light': '#EEDDF5',
+          'mardi-gold-dark': '#4A3C1C',
+          'mardi-gold-light': '#EEE6D2'
+        };
+
         const metaThemeColor = document.querySelector('meta[name="theme-color"]');
-        const darkColor = '#000000';
-        const lightColor = '#ffffff';
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
 
-        // Determine the current theme: stored preference or system preference
-        function getCurrentTheme() {
-          const stored = localStorage.getItem('vivica-theme');
-          if (stored === 'light' || stored === 'dark') {
-            return stored;
+        function getThemeKey() {
+          try {
+            const stored = JSON.parse(localStorage.getItem('vivica-theme') || '{}');
+            const family = stored.color && stored.color !== 'ai-choice' ? stored.color : 'default';
+            const variant = stored.variant || (prefersDark.matches ? 'dark' : 'light');
+            return `${family}-${variant}`;
+          } catch {
+            return prefersDark.matches ? 'default-dark' : 'default-light';
           }
-          // Fallback to system preference
-          return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
         }
 
-        // Apply the appropriate color to the meta tag
-        function applyThemeColor() {
-          const theme = getCurrentTheme();
-          metaThemeColor.setAttribute('content', theme === 'dark' ? darkColor : lightColor);
-        }
-
-        // Initial application
-        applyThemeColor();
-
-        // Listen for changes in system preference
-        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', applyThemeColor);
-
-        // Listen for changes in localStorage (e.g., when the user toggles theme in the app)
-        window.addEventListener('storage', (e) => {
-          if (e.key === 'vivica-theme') {
-            applyThemeColor();
-          }
-        });
+        const key = getThemeKey();
+        const color = STATUSBAR_BG[key] || (prefersDark.matches ? '#000000' : '#FFFFFF');
+        metaThemeColor.setAttribute('content', color);
       })();
     </script>
   </head>

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -6,7 +6,7 @@ import {
   useContext,
 } from 'react';
 import { Capacitor } from '@capacitor/core';
-import { applyStatusBarTheme, ThemeKey } from '@/lib/statusBar';
+import { applyStatusBarTheme, ThemeKey, STATUSBAR_BG } from '@/lib/statusBar';
 import { Storage, DebouncedStorage, STORAGE_KEYS } from '@/utils/storage';
 import { useDynamicTheme } from '@/hooks/useDynamicTheme';
 
@@ -54,10 +54,18 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
   }, [color, variant]);
 
   useEffect(() => {
-    if (!Capacitor.isNativePlatform()) return;
     const family = color === 'ai-choice' ? 'default' : color;
     const themeKey = `${family}-${variant}` as ThemeKey;
-    applyStatusBarTheme(themeKey).catch(() => {});
+
+    // Update PWA status bar color
+    const meta = document.querySelector('meta[name="theme-color"]');
+    if (meta) {
+      meta.setAttribute('content', STATUSBAR_BG[themeKey] ?? '#000000');
+    }
+
+    if (Capacitor.isNativePlatform()) {
+      applyStatusBarTheme(themeKey).catch(() => {});
+    }
   }, [color, variant]);
 
   useDynamicTheme(currentMood, variant, color === 'ai-choice');

--- a/src/lib/statusBar.ts
+++ b/src/lib/statusBar.ts
@@ -17,7 +17,7 @@ export type ThemeMode = 'light' | 'dark'
 export type ThemeKey = `${ThemeFamily}-${ThemeMode}`
 
 /** Pick your exact status bar background per theme variant */
-const STATUSBAR_BG: Record<ThemeKey, string> = {
+export const STATUSBAR_BG: Record<ThemeKey, string> = {
   // Default (Black / White)
   'default-dark': '#000000',
   'default-light': '#FFFFFF',
@@ -33,6 +33,9 @@ const STATUSBAR_BG: Record<ThemeKey, string> = {
   // Purple
   'purple-dark': '#0B0512',
   'purple-light': '#EEDDF5',
+  // Mardi Gold
+  'mardi-gold-dark': '#4A3C1C',
+  'mardi-gold-light': '#EEE6D2',
 }
 
 /** Apply status bar based on your theme key */


### PR DESCRIPTION
## Summary
- export and expand status bar color map for all themes, including Mardi Gold
- update theme hook and index markup so PWA & native apps set status bar color dynamically
- provide dark fallback colors in Android styles for better contrast

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a474f325ec832a9b680648ed92e984