### PR TITLE
Ensure status bar matches active theme

### DIFF
--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -6,7 +6,7 @@ import {
   useContext,
 } from 'react';
 import { Capacitor } from '@capacitor/core';
-import { applyStatusBarTheme, ThemeKey, STATUSBAR_BG } from '@/lib/statusBar';
+import { applyStatusBarTheme, ThemeKey, STATUSBAR_BG } from '@/lib/statusBarService';
 import { Storage, DebouncedStorage, STORAGE_KEYS } from '@/utils/storage';
 import { useDynamicTheme } from '@/hooks/useDynamicTheme';
 
@@ -59,8 +59,10 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
 
     // Update PWA status bar color
     const meta = document.querySelector('meta[name="theme-color"]');
+    const barColor =
+      STATUSBAR_BG[themeKey] ?? (variant === 'light' ? '#FFFFFF' : '#000000');
     if (meta) {
-      meta.setAttribute('content', STATUSBAR_BG[themeKey] ?? '#000000');
+      meta.setAttribute('content', barColor);
     }
 
     if (Capacitor.isNativePlatform()) {

--- a/src/lib/statusBarService.ts
+++ b/src/lib/statusBarService.ts
@@ -12,7 +12,7 @@ function isDarkBg(hex: string): boolean {
   return L < 0.5
 }
 
-export type ThemeFamily = 'default' | 'red' | 'blue' | 'green' | 'purple'
+export type ThemeFamily = 'default' | 'red' | 'blue' | 'green' | 'purple' | 'mardi-gold'
 export type ThemeMode = 'light' | 'dark'
 export type ThemeKey = `${ThemeFamily}-${ThemeMode}`
 
@@ -40,7 +40,8 @@ export const STATUSBAR_BG: Record<ThemeKey, string> = {
 
 /** Apply status bar based on your theme key */
 export async function applyStatusBarTheme(theme: ThemeKey) {
-  const color = STATUSBAR_BG[theme] ?? '#000000'
+  const color =
+    STATUSBAR_BG[theme] ?? (theme.endsWith('-light') ? '#FFFFFF' : '#000000')
 
   // keep content below the status bar (no overlap surprises)
   await StatusBar.setOverlaysWebView({ overlay: false })


### PR DESCRIPTION
## Summary
- centralize status bar helper and handle light/dark fallbacks
- update theme hook to use helper and set meta theme color accordingly

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4dd28fdfc832aab0cc69895ff3668